### PR TITLE
Update js such that if replacement add to cart button is missing, leave existing button

### DIFF
--- a/skin/frontend/base/default/js/scp/scp_product_extension.js
+++ b/skin/frontend/base/default/js/scp/scp_product_extension.js
@@ -268,12 +268,16 @@ Product.Config.prototype.updateProductStock = function(productId) {
     //If config product doesn't already have an additional information section,
     //it won't be shown for associated product either. It's too hard to work out
     //where to place it given that different themes use very different html here
-    $$('p.availability').each(function(el) { 
-        el.replace(stockStatusHtml);
-    });
-    $$('div.add-to-box').each(function(el) { 
-        el.innerHTML=addToCartHtml;
-    });
+	 if (typeof stockStatusHtml !== 'undefined') {
+		 $$('p.availability').each(function(el) { 
+			  el.replace(stockStatusHtml);
+		 });
+	 }
+	 if (typeof addToCartHtml !== 'undefined') {
+		 $$('div.add-to-box').each(function(el) { 
+			  el.innerHTML=addToCartHtml;
+		 });
+	 }
 };
 
 Product.Config.prototype.updateProductSku = function(productId) {


### PR DESCRIPTION
In the event that "add-to-box" is about to be replaced with undefined, just leave it - replacing button with undefined variable removes add to cart button, rendering site useless to customer.

This problem occurred on "awesome" theme - but in general, do not replace perfectly functional button with blank variable. Now makes a check that variable is defined for add to cart button and stock status before replacing existing content. Tested and working - no change to behaviour if variable is loaded correctly.
